### PR TITLE
Move metadata needed by Provisioner to ImportStatus

### DIFF
--- a/internal/slack/messages.go
+++ b/internal/slack/messages.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"log"
 	"os"
+	"strings"
 
 	mmetl "github.com/mattermost/mmetl/services/slack"
 )
@@ -14,7 +15,7 @@ import (
 // in the JSONL lines that make up the MBIF referring to any attached
 // files in attachmentsDir. The attached files will also be extracted
 // from the file at inputFilePath and stored in attachmentsDir
-func TransformSlack(inputFilePath, outputFilePath, team, attachmentsDir string) error {
+func TransformSlack(inputFilePath, outputFilePath, team, attachmentsDir, workdir string) error {
 	// input file
 	fileReader, err := os.Open(inputFilePath)
 	if err != nil {
@@ -42,10 +43,19 @@ func TransformSlack(inputFilePath, outputFilePath, team, attachmentsDir string) 
 		return err
 	}
 
+	// TODO maybe change mmetl to include the correct paths during
+	// Transform -- however this seems to be fairly involved so for now
+	// just fix these paths after the fact
+	for _, post := range intermediate.Posts {
+		for i, attachment := range post.Attachments {
+			post.Attachments[i] = strings.TrimPrefix(attachment, workdir)
+		}
+	}
+
 	if err = mmetl.Export(team, intermediate, outputFilePath); err != nil {
 		return err
 	}
 
-	log.Println("Transformation succeeded!!")
+	log.Println("Transformation succeeded")
 	return nil
 }

--- a/internal/slack/translator.go
+++ b/internal/slack/translator.go
@@ -60,16 +60,19 @@ func (st *SlackTranslator) Translate(translation *model.Translation) (string, er
 		mbifName,
 		translation.Team,
 		attachmentDirName,
+		workdir,
 	)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to transform Slack archive to MBIF")
 	}
 
+	logger.Infof("Preparing Mattermost archive for Translation %s for upload", translation.ID)
 	outputZip, err := st.createOutputZipfile(logger, attachmentDirName, mbifName, translation.ID)
 	if err != nil {
 		return "", err
 	}
 
+	logger.Infof("Uploading Mattermost archive for Translation %s", translation.ID)
 	err = st.uploadTransformedZip(outputZip, st.bucket)
 	if err != nil {
 		return "", err

--- a/internal/store/import.go
+++ b/internal/store/import.go
@@ -21,6 +21,7 @@ func init() {
 			"LockedBy",
 			"StartAt",
 			"TranslationID",
+			"Resource",
 		).
 		From(ImportTableName)
 }
@@ -103,6 +104,7 @@ func (sqlStore *SQLStore) StoreImport(imp *model.Import) error {
 			"LockedBy":      imp.LockedBy,
 			"StartAt":       imp.StartAt,
 			"TranslationID": imp.TranslationID,
+			"Resource":      imp.Resource,
 		}),
 	)
 	return err
@@ -119,6 +121,7 @@ func (sqlStore *SQLStore) UpdateImport(imp *model.Import) error {
 			"LockedBy":      imp.LockedBy,
 			"StartAt":       imp.StartAt,
 			"TranslationID": imp.TranslationID,
+			"Resource":      imp.Resource,
 		}).
 		Where("ID = ?", imp.ID),
 	)
@@ -151,7 +154,7 @@ func (sqlStore *SQLStore) GetImportsByInstallation(id string) ([]*model.Import, 
 // owner, but will not do so if the column already contains something,
 // and will return an error instead in that case
 func (sqlStore *SQLStore) TryLockImport(imp *model.Import, owner string) error {
-	sqlStore.logger.Infof("locking %s as %s", imp.ID, owner)
+	sqlStore.logger.Infof("Locking Import %s as %s", imp.ID, owner)
 	imp.LockedBy = owner
 
 	result, err := sqlStore.execBuilder(

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -34,11 +34,10 @@ var migrations = []migration{
 
 			_, err = e.Exec(`
 				CREATE TABLE Translation (
-						ID              TEXT PRIMARY KEY,
+						ID              TEXT PRIMARY KEY NOT NULL,
 						InstallationID  TEXT,
 						Type            TEXT,
 						Resource        TEXT,
-						Output          TEXT,
 						Error           TEXT,
 						CreateAt        BigInt,
 						StartAt         BigInt,
@@ -48,11 +47,12 @@ var migrations = []migration{
 				);
 
 				CREATE TABLE Import (
-						ID             TEXT PRIMARY KEY,
+						ID             TEXT PRIMARY KEY NOT NULL,
 						CreateAt       BigInt,
 						CompleteAt     BigInt,
 						StartAt        BigInt,
 						LockedBy       TEXT,
+						Resource       TEXT,
 						TranslationID  TEXT
 				);
 

--- a/internal/store/translation.go
+++ b/internal/store/translation.go
@@ -18,11 +18,9 @@ func init() {
 			"CompleteAt",
 			"CreateAt",
 			"StartAt",
-
 			"ID",
 			"InstallationID",
 			"LockedBy",
-			"Output",
 			"Resource",
 			"Team",
 			"Type",
@@ -120,7 +118,6 @@ func (sqlStore *SQLStore) StoreTranslation(translation *model.Translation) error
 			"ID":             translation.ID,
 			"InstallationID": translation.InstallationID,
 			"LockedBy":       translation.LockedBy,
-			"Output":         translation.Output,
 			"Resource":       translation.Resource,
 			"Team":           translation.Team,
 			"Type":           translation.Type,
@@ -142,7 +139,6 @@ func (sqlStore *SQLStore) UpdateTranslation(translation *model.Translation) erro
 			"ID":             translation.ID,
 			"InstallationID": translation.InstallationID,
 			"LockedBy":       translation.LockedBy,
-			"Output":         translation.Output,
 			"Resource":       translation.Resource,
 			"Team":           translation.Team,
 			"Type":           translation.Type,
@@ -154,7 +150,7 @@ func (sqlStore *SQLStore) UpdateTranslation(translation *model.Translation) erro
 // TryLockTranslation attempts to claim the given translation for the
 // owner ID provided and returns an error if it fails to do so
 func (sqlStore *SQLStore) TryLockTranslation(translation *model.Translation, owner string) error {
-	sqlStore.logger.Infof("Locking %s as %s", translation.ID, owner)
+	sqlStore.logger.Infof("Locking Translation %s as %s", translation.ID, owner)
 	translation.LockedBy = owner
 
 	result, err := sqlStore.execBuilder(

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -1,6 +1,7 @@
 package supervisor
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -89,13 +90,13 @@ func (s *Supervisor) supervise() error {
 	}
 
 	translation.CompleteAt = model.Timestamp()
-	translation.Output = output
 	err = s.store.UpdateTranslation(translation)
 	if err != nil {
 		return errors.Wrapf(err, "failed to store completed Translation %s; the Translation may be erroneously repeated!", translation.ID)
 	}
 
-	imp := model.NewImport(translation.ID)
+	importResource := fmt.Sprintf("%s/%s", s.bucket, output)
+	imp := model.NewImport(translation.ID, importResource)
 	err = s.store.StoreImport(imp)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create an Import for Translation %s; the Translation may be complete but it will not be imported automatically", translation.ID)

--- a/model/import.go
+++ b/model/import.go
@@ -16,12 +16,14 @@ const (
 // Import represents a completed Translation that is being imported
 // into an Installation in order to track that process
 type Import struct {
-	ID            string
-	CreateAt      int64
-	CompleteAt    int64
-	StartAt       int64
-	LockedBy      string
-	TranslationID string
+	ID             string
+	CreateAt       int64
+	CompleteAt     int64
+	StartAt        int64
+	LockedBy       string
+	TranslationID  string
+	InstallationID string
+	Resource       string
 }
 
 // ImportWorkRequest contains an identifier from the caller in order
@@ -32,11 +34,12 @@ type ImportWorkRequest struct {
 
 // NewImport creates an Import with the appropriate creation-time
 // metadata and associates it with the given translationID
-func NewImport(translationID string) *Import {
+func NewImport(translationID string, input string) *Import {
 	return &Import{
 		ID:            NewID(),
 		TranslationID: translationID,
 		CreateAt:      Timestamp(),
+		Resource:      input,
 	}
 }
 
@@ -46,7 +49,8 @@ func NewImport(translationID string) *Import {
 type ImportStatus struct {
 	Import
 
-	State string
+	InstallationID string
+	State          string
 }
 
 // State determines and returns the current state of the Import given

--- a/model/import.go
+++ b/model/import.go
@@ -16,14 +16,13 @@ const (
 // Import represents a completed Translation that is being imported
 // into an Installation in order to track that process
 type Import struct {
-	ID             string
-	CreateAt       int64
-	CompleteAt     int64
-	StartAt        int64
-	LockedBy       string
-	TranslationID  string
-	InstallationID string
-	Resource       string
+	ID            string
+	CreateAt      int64
+	CompleteAt    int64
+	StartAt       int64
+	LockedBy      string
+	TranslationID string
+	Resource      string
 }
 
 // ImportWorkRequest contains an identifier from the caller in order


### PR DESCRIPTION

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This change allows the Provisioner to get an Import that is ready to go and all of the necessary metadata (InstallationID and full Resource of the output zip file including the bucket) to actually perform the import with a single call instead of two.

This PR is necessary for https://github.com/mattermost/mattermost-cloud/pull/439
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
No ticket
