### PR TITLE
Fix incorrect attached file paths in completed Translation

### DIFF
--- a/internal/slack/messages.go
+++ b/internal/slack/messages.go
@@ -47,10 +47,6 @@ func TransformSlack(inputFilePath, outputFilePath, team, attachmentsDir, workdir
 	// Transform -- however this seems to be fairly involved so for now
 	// just fix these paths after the fact
 	for _, post := range intermediate.Posts {
-		if len(post.Attachments) < 1 {
-			continue
-		}
-
 		for i, attachment := range post.Attachments {
 			post.Attachments[i] = strings.TrimPrefix(attachment, workdir)
 		}

--- a/internal/slack/translator.go
+++ b/internal/slack/translator.go
@@ -60,16 +60,19 @@ func (st *SlackTranslator) Translate(translation *model.Translation) (string, er
 		mbifName,
 		translation.Team,
 		attachmentDirName,
+		workdir,
 	)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to transform Slack archive to MBIF")
 	}
 
+	logger.Infof("Preparing Mattermost archive for Translation %s for upload", translation.ID)
 	outputZip, err := st.createOutputZipfile(logger, attachmentDirName, mbifName, translation.ID)
 	if err != nil {
 		return "", err
 	}
 
+	logger.Infof("Uploading Mattermost archive for Translation %s", translation.ID)
 	err = st.uploadTransformedZip(outputZip, st.bucket)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Fixes a problem where paths to file attachments erroneously contained the path of the working directory the MBIF archive was built in, local to the AWAT

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-34372
