### PR TITLE
Fix bug in attachment paths in zipfile & add needed metadata

### DIFF
--- a/internal/api/import.go
+++ b/internal/api/import.go
@@ -122,6 +122,8 @@ func importStatusFromImport(imp *model.Import, store Store) (*model.ImportStatus
 	return &model.ImportStatus{
 		Import:         *imp,
 		InstallationID: translation.InstallationID,
+		Users:          translation.Users,
+		Team:           translation.Team,
 		State:          imp.State(),
 	}, nil
 }

--- a/internal/slack/messages.go
+++ b/internal/slack/messages.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/mattermost/awat/model"
 	mmetl "github.com/mattermost/mmetl/services/slack"
 )
 
@@ -15,7 +16,7 @@ import (
 // in the JSONL lines that make up the MBIF referring to any attached
 // files in attachmentsDir. The attached files will also be extracted
 // from the file at inputFilePath and stored in attachmentsDir
-func TransformSlack(inputFilePath, outputFilePath, team, attachmentsDir, workdir string) error {
+func TransformSlack(translation *model.Translation, inputFilePath, outputFilePath, attachmentsDir, workdir string) error {
 	// input file
 	fileReader, err := os.Open(inputFilePath)
 	if err != nil {
@@ -33,7 +34,7 @@ func TransformSlack(inputFilePath, outputFilePath, team, attachmentsDir, workdir
 		return err
 	}
 
-	slackExport, err := mmetl.ParseSlackExportFile(team, zipReader, false)
+	slackExport, err := mmetl.ParseSlackExportFile(translation.Team, zipReader, false)
 	if err != nil {
 		return err
 	}
@@ -52,7 +53,10 @@ func TransformSlack(inputFilePath, outputFilePath, team, attachmentsDir, workdir
 		}
 	}
 
-	if err = mmetl.Export(team, intermediate, outputFilePath); err != nil {
+	// this total may include bots
+	translation.Users = len(intermediate.UsersById)
+
+	if err = mmetl.Export(translation.Team, intermediate, outputFilePath); err != nil {
 		return err
 	}
 

--- a/internal/slack/translator.go
+++ b/internal/slack/translator.go
@@ -56,9 +56,9 @@ func (st *SlackTranslator) Translate(translation *model.Translation) (string, er
 	mbifName := fmt.Sprintf("%s/%s_MBIF.jsonl", workdir, translation.InstallationID)
 	logger.Infof("Transforming Slack archive for Translation %s to MBIF", translation.ID)
 	err = TransformSlack(
+		translation,
 		archiveWithFilesName,
 		mbifName,
-		translation.Team,
 		attachmentDirName,
 		workdir,
 	)

--- a/internal/slack/translator.go
+++ b/internal/slack/translator.go
@@ -143,9 +143,9 @@ func (st *SlackTranslator) addFilesToSlackArchive(logger logrus.FieldLogger, wor
 		return "", errors.Wrap(err, "failed to fetch attached files")
 	}
 
-	err = os.Mkdir(attachmentDirName, 0700)
+	err = os.MkdirAll(attachmentDirName, 0700)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to create attachments directory")
+		return "", errors.Wrapf(err, "failed to create attachments directory %s", attachmentDirName)
 	}
 
 	return withFiles.Name(), nil

--- a/internal/slack/translator.go
+++ b/internal/slack/translator.go
@@ -189,7 +189,7 @@ func (st *SlackTranslator) createOutputZipfile(logger logrus.FieldLogger, attach
 		if attachment.IsDir() {
 			continue
 		}
-		attachmentInZipfile, err := outputZipfile.Create(fmt.Sprintf("attachments/%s", attachment.Name()))
+		attachmentInZipfile, err := outputZipfile.Create(fmt.Sprintf("/data/attachments/%s", attachment.Name()))
 		if err != nil {
 			logger.WithError(err).Error("failed to write attachment")
 			continue
@@ -199,8 +199,8 @@ func (st *SlackTranslator) createOutputZipfile(logger logrus.FieldLogger, attach
 			logger.WithError(err).Errorf("failed to open attachment file %s", attachmentDirName+attachment.Name())
 			continue
 		}
+		defer attachmentFile.Close()
 		_, err = io.Copy(attachmentInZipfile, attachmentFile)
-		_ = attachmentFile.Close()
 		if err != nil {
 			logger.
 				WithError(err).

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -43,6 +43,7 @@ var migrations = []migration{
 						StartAt         BigInt,
 						CompleteAt      BigInt,
 						Team            TEXT,
+						Users           Integer,
 						LockedBy        TEXT
 				);
 

--- a/internal/store/translation.go
+++ b/internal/store/translation.go
@@ -23,6 +23,7 @@ func init() {
 			"LockedBy",
 			"Resource",
 			"Team",
+			"Users",
 			"Type",
 		).
 		From(TranslationTableName)
@@ -120,6 +121,7 @@ func (sqlStore *SQLStore) StoreTranslation(translation *model.Translation) error
 			"LockedBy":       translation.LockedBy,
 			"Resource":       translation.Resource,
 			"Team":           translation.Team,
+			"Users":          translation.Users,
 			"Type":           translation.Type,
 		}),
 	)
@@ -141,6 +143,7 @@ func (sqlStore *SQLStore) UpdateTranslation(translation *model.Translation) erro
 			"LockedBy":       translation.LockedBy,
 			"Resource":       translation.Resource,
 			"Team":           translation.Team,
+			"Users":          translation.Users,
 			"Type":           translation.Type,
 		}).Where("ID = ?", translation.ID),
 	)

--- a/model/import.go
+++ b/model/import.go
@@ -49,6 +49,8 @@ type ImportStatus struct {
 	Import
 
 	InstallationID string
+	Users          int
+	Team           string
 	State          string
 }
 

--- a/model/translation.go
+++ b/model/translation.go
@@ -12,8 +12,8 @@ type Translation struct {
 	ID             string
 	InstallationID string
 	Team           string
+	Users          int
 	Type           string
-	Output         string
 	Resource       string
 	CreateAt       int64
 	StartAt        int64


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

This PR does 2 things:

1) Corrects the paths of the files _inside_ the output zip file so that attachments are under /data/attachments where the importer expects them

2) Adds Users to the Translation object so it can be stored when we discover how many users are in the import

2) Adds Users and Team to the ImportStatus struct: this is because the Provisioner must know the Team name into which the Import is destined, and it also must know how many users will be imported so that it can pre-emptively expand the Max Users setting on the Server so that the import does not fail due to there not being enough users allowed

This change is needed for https://github.com/mattermost/mattermost-cloud/pull/439 to be merged

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
No ticket

