### PR TITLE
Add Import Supervisor to complete Imports

### DIFF
--- a/internal/api/import.go
+++ b/internal/api/import.go
@@ -54,6 +54,8 @@ func handleReleaseLockOnImport(c *Context, w http.ResponseWriter, r *http.Reques
 	}
 
 	imprt.LockedBy = ""
+	imprt.StartAt = 0
+
 	err = c.Store.UpdateImport(imprt)
 	if err != nil {
 		c.Logger.WithError(err).Errorf("failed to release lock on Import %s", importID)

--- a/internal/api/store.go
+++ b/internal/api/store.go
@@ -12,6 +12,7 @@ type Store interface {
 	GetAndClaimNextReadyImport(provisionerID string) (*model.Import, error)
 	GetAllImports() ([]*model.Import, error)
 	GetImport(id string) (*model.Import, error)
+	GetImportsInProgress() ([]*model.Import, error)
 	GetImportsByInstallation(id string) ([]*model.Import, error)
 	GetImportsByTranslation(id string) ([]*model.Import, error)
 	UpdateImport(imp *model.Import) error

--- a/internal/store/import.go
+++ b/internal/store/import.go
@@ -167,6 +167,19 @@ func (sqlStore *SQLStore) GetImportsByTranslation(id string) ([]*model.Import, e
 	return *imprts, nil
 }
 
+func (sqlStore *SQLStore) GetImportsInProgress() ([]*model.Import, error) {
+	imprts := &[]*model.Import{}
+	err := sqlStore.selectBuilder(sqlStore.db, imprts,
+		importSelect.Where("CompleteAt = 0"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return *imprts, nil
+
+}
+
 // TryLockImport attempts to lock the input Import with the given
 // owner, but will not do so if the column already contains something,
 // and will return an error instead in that case

--- a/internal/supervisor/import.go
+++ b/internal/supervisor/import.go
@@ -51,9 +51,10 @@ func (s *ImportSupervisor) supervise() error {
 
 	for _, i := range imports {
 		if (time.Now().UnixNano()/1000)-i.StartAt < time.Second.Milliseconds()*10 {
-			// if the above condition is true, the Import is very new (less
-			// than 10 seconds old) and it's possible that the Provisioner
-			// hasn't picked it up yet
+			// if the above condition is true, the Import was claimed to be
+			// started very recently (less than 10 seconds ago) and it's
+			// possible that the Provisioner hasn't changed the state on the
+			// corresponding Installation yet
 
 			// the first thing the Provisioner does after getting some work
 			// is to lock the Installation, so the window for a race

--- a/internal/supervisor/import.go
+++ b/internal/supervisor/import.go
@@ -1,0 +1,94 @@
+package supervisor
+
+import (
+	"time"
+
+	"github.com/mattermost/awat/model"
+	cloud "github.com/mattermost/mattermost-cloud/model"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+type ImportSupervisor struct {
+	logger log.FieldLogger
+	store  importStore
+	cloud  *cloud.Client
+}
+
+type importStore interface {
+	GetImportsInProgress() ([]*model.Import, error)
+	GetTranslation(id string) (*model.Translation, error)
+	UpdateImport(imp *model.Import) error
+}
+
+func NewImportSupervisor(store importStore, logger log.FieldLogger, provisionerURL string) *ImportSupervisor {
+	cloudClient := cloud.NewClient(provisionerURL)
+	return &ImportSupervisor{
+		logger: logger,
+		store:  store,
+		cloud:  cloudClient,
+	}
+}
+
+func (s *ImportSupervisor) Start() {
+	s.logger.Info("Import supervisor started")
+	go func() {
+		for {
+			err := s.supervise()
+			if err != nil {
+				s.logger.WithError(err).Error("failed an operation while supervising imports")
+			}
+			time.Sleep(60 * time.Second)
+		}
+	}()
+}
+
+func (s *ImportSupervisor) supervise() error {
+	imports, err := s.store.GetImportsInProgress()
+	if err != nil {
+		return errors.Wrap(err, "failed to look up ongoing Imports to supervise")
+	}
+
+	for _, i := range imports {
+		if (time.Now().UnixNano()/1000)-i.StartAt < time.Second.Milliseconds()*10 {
+			// if the above condition is true, the Import is very new (less
+			// than 10 seconds old) and it's possible that the Provisioner
+			// hasn't picked it up yet
+
+			// the first thing the Provisioner does after getting some work
+			// is to lock the Installation, so the window for a race
+			// condition should be a sub-second window and this pause should
+			// be reliable if slightly overkill
+			continue
+		}
+
+		translation, err := s.store.GetTranslation(i.TranslationID)
+		if err != nil {
+			s.logger.WithError(err).Warnf("failed to look up Translation %s", i.TranslationID)
+			continue
+		}
+
+		installation, err := s.cloud.GetInstallation(
+			translation.InstallationID,
+			&cloud.GetInstallationRequest{
+				IncludeGroupConfig:          false,
+				IncludeGroupConfigOverrides: false,
+			})
+		if err != nil {
+			s.logger.WithError(err).Warnf("failed to fetch information on Installation %s", translation.InstallationID)
+			continue
+		}
+
+		// if the State is stable and the Installation is slightly old, we
+		// can safely assume that an import happened and was completed
+		if installation.State == "stable" {
+			i.CompleteAt = time.Now().Unix() / 1000
+			err := s.store.UpdateImport(i)
+			if err != nil {
+				s.logger.WithError(err).Warnf("Import %s was done but couldn't be marked as such", i.ID)
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/supervisor/translation.go
+++ b/internal/supervisor/translation.go
@@ -12,21 +12,21 @@ import (
 	"github.com/mattermost/awat/model"
 )
 
-// Supervisor is responsible for scheduling and launching Translations
+// TranslationSupervisor is responsible for scheduling and launching Translations
 // in series
-type Supervisor struct {
+type TranslationSupervisor struct {
 	logger  log.FieldLogger
 	store   *store.SQLStore
 	bucket  string
 	workdir string
 }
 
-// NewSupervisor returns a Supervisor prepared with the needed
+// NewTranslationSupervisor returns a Supervisor prepared with the needed
 // metadata to operate
-func NewSupervisor(store *store.SQLStore, logger log.FieldLogger, bucket, workdir string) *Supervisor {
-	return &Supervisor{
+func NewTranslationSupervisor(store *store.SQLStore, logger log.FieldLogger, bucket, workdir string) *TranslationSupervisor {
+	return &TranslationSupervisor{
 		store:   store,
-		logger:  logger.WithField("supervisor", model.NewID()),
+		logger:  logger.WithField("translation-supervisor", model.NewID()),
 		bucket:  bucket,
 		workdir: workdir,
 	}
@@ -34,8 +34,8 @@ func NewSupervisor(store *store.SQLStore, logger log.FieldLogger, bucket, workdi
 
 // Start runs the Supervisor's main routine on a new goroutine both
 // periodically and forever
-func (s *Supervisor) Start() {
-	s.logger.Info("Supervisor started")
+func (s *TranslationSupervisor) Start() {
+	s.logger.Info("Translation supervisor started")
 	go func() {
 		for {
 			err := s.supervise()
@@ -49,7 +49,7 @@ func (s *Supervisor) Start() {
 
 // supervise queries the database for available Translations and
 // works through the batch returned serially
-func (s *Supervisor) supervise() error {
+func (s *TranslationSupervisor) supervise() error {
 	translation, err := s.store.GetTranslationReadyToStart()
 	if err != nil {
 		return errors.Wrap(err, "Failed to query database for pending translations")


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

As a follow up to https://github.com/mattermost/mattermost-cloud/pull/439#discussion_r624807755 , this PR adds an Import Supervisor to the AWAT as well, which periodically queries the Provisioner for the states of any Installations related to Imports that it sees as in-progress in its database and which are older than 45 seconds, and marks those Imports as complete if the Installation has reached `stable`.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
No ticket
