### PR TITLE
Rework the file paths slightly to match changes in Bulk Importer

### DIFF
--- a/internal/slack/messages.go
+++ b/internal/slack/messages.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/mattermost/awat/model"
@@ -49,7 +50,11 @@ func TransformSlack(translation *model.Translation, inputFilePath, outputFilePat
 	// just fix these paths after the fact
 	for _, post := range intermediate.Posts {
 		for i, attachment := range post.Attachments {
-			post.Attachments[i] = strings.TrimPrefix(attachment, workdir)
+			path, err := filepath.Abs("/data" + strings.TrimPrefix(attachment, workdir))
+			if err != nil {
+				return err
+			}
+			post.Attachments[i] = path
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
As part of MM-31612 I'm changing [the import worker process](https://github.com/mattermost/mattermost-server/pull/17659/files#diff-a00842e7d15ed56360297634e99fdfcfcfc1a88e577fcd448284a63d7434e664R170) to use [`BulkImport`](https://github.com/mattermost/mattermost-server/blob/master/app/import.go#L126) instead of [`BulkImportWithPath`](https://github.com/mattermost/mattermost-server/blob/master/app/import.go#L130) so that the archive is streamed. This change adjusts the paths to match what Mattermost expects after the change to Mattermost is in place.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

This is related to MM-31612 but isn't covered by that ticket. This change is necessary for the fully automated import process, but the streaming import change to Mattermost does not rely on this change.