### PR TITLE
Fix a couple of bugs in the AWAT Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,6 @@ build: ## build the AWAT
 
 build-image:   ## Build the docker image for the AWAT
 	@echo Building AWAT Docker Image
-	podman build \
+	docker build \
 	. -f build/Dockerfile -t $(AWAT_IMAGE) 
 # --no-cache

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,6 @@ build: ## build the AWAT
 
 build-image:   ## Build the docker image for the AWAT
 	@echo Building AWAT Docker Image
-	docker build \
+	podman build \
 	. -f build/Dockerfile -t $(AWAT_IMAGE) 
 # --no-cache

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 # See LICENSE.txt for license information.
-ARG DOCKER_BUILD_IMAGE=docker.io/library/golang:1.15
-ARG DOCKER_BASE_IMAGE=docker.io/library/alpine:3.12
+ARG DOCKER_BUILD_IMAGE=golang:1.15
+ARG DOCKER_BASE_IMAGE=alpine:3.12
 
 FROM ${DOCKER_BUILD_IMAGE} AS build
 WORKDIR /awat/

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 # See LICENSE.txt for license information.
-ARG DOCKER_BUILD_IMAGE=golang:1.15
-ARG DOCKER_BASE_IMAGE=alpine:3.12
+ARG DOCKER_BUILD_IMAGE=docker.io/library/golang:1.15
+ARG DOCKER_BASE_IMAGE=docker.io/library/alpine:3.12
 
 FROM ${DOCKER_BUILD_IMAGE} AS build
 WORKDIR /awat/
@@ -18,12 +18,9 @@ LABEL name="Mattermost Cloud Automatic Workspace Archive Translator" \
   io.k8s.description="Mattermost Cloud AWAT converts workspace archives into a Mattermost-native import format" \
   io.k8s.display-name="Mattermost Cloud AWAT"
 
-ENV USER_UID=10001 \
-    USER_NAME=awat
-
 COPY --from=build /awat/build/_output/bin/awat /usr/local/bin/awat
 
 USER ${USER_UID}
 
 EXPOSE 8099
-ENTRYPOINT /usr/local/bin/awat
+ENTRYPOINT ["/usr/local/bin/awat"]


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
~~To match the patterns in our other repositories, this changes the AWAT to use `podman` instead of `docker` for building container images, both in the `Makefile` and in the `Dockerfile`~~

This PR fixes two bugs that I discovered while testing the Kubernetes Deployment for this service:
- incorrect UID 
- incorrect `ENTRYPOINT` statement in the Dockerfile) 