### PR TITLE
Support importing Mattermost Workspaces

### DIFF
--- a/cmd/awat/translation.go
+++ b/cmd/awat/translation.go
@@ -126,7 +126,8 @@ var startTranslationCmd = &cobra.Command{
 			return errors.New("the installation ID to which this translation pertains must be specified")
 		}
 		team, _ := cmd.Flags().GetString(teamFlag)
-		if team == "" {
+		if team == "" && translationType != model.MattermostWorkspaceBackupType {
+			// Mattermost backups include their team names, but other types don't
 			return errors.New("the team name to which this translation pertains must be specified")
 		}
 		archive, _ := cmd.Flags().GetString(archiveFilename)

--- a/cmd/awat/translation.go
+++ b/cmd/awat/translation.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 
 	"github.com/mattermost/awat/model"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -118,7 +118,7 @@ var startTranslationCmd = &cobra.Command{
 		translationType, _ := cmd.Flags().GetString(translationTypeFlag)
 		if translationType != model.MattermostWorkspaceBackupType &&
 			translationType != model.SlackWorkspaceBackupType {
-			return fmt.Errorf("unknown Translation type \"%s\" provided", translationType)
+			return errors.Errorf("unknown Translation type %q provided", translationType)
 		}
 
 		installation, _ := cmd.Flags().GetString(installationID)

--- a/internal/api/import.go
+++ b/internal/api/import.go
@@ -182,6 +182,7 @@ func importStatusFromImport(imp *model.Import, store Store) (*model.ImportStatus
 		Users:          translation.Users,
 		Team:           translation.Team,
 		State:          imp.State(),
+		Type:           translation.Type,
 	}, nil
 }
 

--- a/internal/mattermost/translator.go
+++ b/internal/mattermost/translator.go
@@ -1,0 +1,13 @@
+package mattermost
+
+import "github.com/mattermost/awat/model"
+
+type MattermostTranslator struct{}
+
+func NewMattermostTranslator() *MattermostTranslator {
+	return &MattermostTranslator{}
+}
+
+func (mt *MattermostTranslator) Translate(translation *model.Translation) (string, error) {
+	return translation.Resource, nil
+}

--- a/internal/supervisor/import.go
+++ b/internal/supervisor/import.go
@@ -79,6 +79,10 @@ func (s *ImportSupervisor) supervise() error {
 			s.logger.WithError(err).Warnf("failed to fetch information on Installation %s", translation.InstallationID)
 			continue
 		}
+		if installation == nil {
+			s.logger.WithError(errors.New("Installation not found")).Warnf("Installation with ID %s not found but no error was returned from the Provisioner", translation.InstallationID)
+			continue
+		}
 
 		// if the State is stable and the Installation is slightly old, we
 		// can safely assume that an import happened and was completed

--- a/internal/translator/translator.go
+++ b/internal/translator/translator.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/mattermost/awat/internal/mattermost"
 	"github.com/mattermost/awat/internal/slack"
 	"github.com/mattermost/awat/model"
 )
@@ -30,9 +31,13 @@ func NewTranslator(t *TranslatorOptions) (Translator, error) {
 		return nil, errors.New("options struct must not be nil")
 	}
 
-	if t.ArchiveType != model.SlackWorkspaceBackupType {
-		return nil, fmt.Errorf("%s is not a supported workspace archive input type", t.ArchiveType)
+	if t.ArchiveType == model.SlackWorkspaceBackupType {
+		return slack.NewSlackTranslator(t.Bucket, t.WorkingDir), nil
 	}
 
-	return slack.NewSlackTranslator(t.Bucket, t.WorkingDir), nil
+	if t.ArchiveType == model.MattermostWorkspaceBackupType {
+		return mattermost.NewMattermostTranslator(), nil
+	}
+
+	return nil, fmt.Errorf("%s is not a supported workspace archive input type", t.ArchiveType)
 }

--- a/model/import.go
+++ b/model/import.go
@@ -63,6 +63,7 @@ type ImportStatus struct {
 	Users          int
 	Team           string
 	State          string
+	Type           string
 }
 
 // State determines and returns the current state of the Import given

--- a/model/translation.go
+++ b/model/translation.go
@@ -46,7 +46,10 @@ func (t *Translation) State() string {
 // NewTranslationFromRequest creates a new Translation from a
 // TranslationRequest
 func NewTranslationFromRequest(translationRequest *TranslationRequest) *Translation {
-	teamName := cleanTeamName(translationRequest.Team)
+	teamName := translationRequest.Team
+	if translationRequest.Type != MattermostWorkspaceBackupType {
+		teamName = cleanTeamName(teamName)
+	}
 
 	return &Translation{
 		ID:             NewID(),

--- a/model/translation_request.go
+++ b/model/translation_request.go
@@ -7,7 +7,10 @@ import (
 	"github.com/pkg/errors"
 )
 
-const SlackWorkspaceBackupType string = "slack"
+const (
+	SlackWorkspaceBackupType      string = "slack"
+	MattermostWorkspaceBackupType string = "mattermost"
+)
 
 type TranslationRequest struct {
 	Type           string


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Adds a type `mattermost` to the type of Translations that the AWAT can handle. This is a no-op type (skips the Translation step) that merely prepares the metadata needed for the Provisioner to import the provided Workspace export (MBIF) file.

Adds the flag `--type` to `awat translation start` for specifying the type of Workspace being translated/imported. For now, the default is `slack` and the only two valid options are `slack` and `mattermost`.

Example usage:
1. Copy MBIF to the S3 bucket used by the AWAT with some name, e.g. `sampledata_export.zip`
2. Start the import: `awat translation start --installation-id 5ug7re4dbfy5pdufc5sn9h5x1y --filename 'sampledata_export.zip' --type mattermost`

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
No ticket

#### Note
This change includes the commit from PR #10 and they'll be visible in the diff here until that PR is merged.
