### PR TITLE
Add a test that does two translations and imports in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,13 +31,16 @@ test: build
 mocks:
 	mockgen -source ./internal/api/store.go Store -package mocks > ./internal/mocks/api/store.go
 
-e2e: e2e-warn e2e-mattermost e2e-slack
+e2e: e2e-warn e2e-mattermost e2e-slack e2e-parallel
 
 e2e-slack:
 	go test -v -tags e2e -count 1 ./test/e2e -timeout 30m -run Slack
 
 e2e-mattermost:
 	go test -v -tags e2e -count 1 ./test/e2e -timeout 15m -run Mattermost
+
+e2e-parallel:
+	go test -v -tags e2e -count 1 ./test/e2e -timeout 30m -run TwoInQuickSuccession
 
 e2e-warn:
 	@echo Warning!


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Tests that two translations can be launched in quick succession, and that the imports still complete. 

This test could probably be cleaned up a bit with a couple of helper functions but I'm not going to spend the time on it unless y'all think it's necessary since I doubt they'd be reused outside of this test and I don't think this test will require much ongoing maintenance.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
This PR finally completes [MM-37234](https://mattermost.atlassian.net/browse/MM-37234)

#### Example output:
```
~/g/s/g/m/awat » make e2e-parallel
go test -v -tags e2e -count 1 ./test/e2e -timeout 30m -run TwoInQuickSuccession
=== RUN   TestTwoInQuickSuccession
    e2e_test.go:192: validate the environment and gather variables
    e2e_test.go:212: clean up the environment from any previously interrupted tests
    e2e_test.go:240: create an Installation into which to run an import
    e2e_test.go:271: wait for the Installation to become stable
    e2e_test.go:240: create an Installation into which to run an import
    e2e_test.go:271: wait for the Installation to become stable
    e2e_test.go:312: start a new translation into installation tpkzzxcfuigaxjxigoxiq5qicw
    e2e_test.go:312: start a new translation into installation t66mxjnrejgq5exdkwht17wyko
    e2e_test.go:331: wait for translation o6qykjczijypbkkm44xqsm5j1w to start
    e2e_test.go:331: wait for translation shd385idppfbjemfy1mga8nz9o to start
    e2e_test.go:365: wait for translation shd385idppfbjemfy1mga8nz9o to complete
    e2e_test.go:365: wait for translation o6qykjczijypbkkm44xqsm5j1w to complete
    e2e_test.go:390: make sure an import is created and wait for it to start
    e2e_test.go:390: make sure an import is created and wait for it to start
    e2e_test.go:425: wait for import z736x7m4b7godk7ywdzq7tuqtc to complete
    e2e_test.go:425: wait for import a45hqgicubrhpq9ime9bg1i3ac to complete
    e2e_test.go:100: validate the import data was imported properly
    e2e_test.go:103: checking import into installation t66mxjnrejgq5exdkwht17wyko
    e2e_test.go:517: check teams
    e2e_test.go:541: check channels
    e2e_test.go:624: check users
    e2e_test.go:586: check posts
    e2e_test.go:103: checking import into installation tpkzzxcfuigaxjxigoxiq5qicw
    e2e_test.go:517: check teams
    e2e_test.go:541: check channels
    e2e_test.go:624: check users
    e2e_test.go:586: check posts
--- PASS: TestTwoInQuickSuccession (1132.55s)
PASS
ok  	github.com/mattermost/awat/test/e2e	1132.582s
```