### PR TITLE
Add Dockerfile for E2E tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ test: build
 	@echo Running tests
 	go test ./...
 
+test-image:
+	docker build -f test/Dockerfile .
+
 mocks:
 	mockgen -source ./internal/api/store.go Store -package mocks > ./internal/mocks/api/store.go
 

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,5 +1,5 @@
-from golang:1.14
-workdir /awat/
-copy . /awat/
-run make build
-entrypoint ["/usr/bin/make", "e2e"]
+FROM golang:1.15
+WORKDIR /awat/
+COPY . /awat/
+RUN make build
+ENTRYPOINT ["/usr/bin/make", "e2e"]

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,5 @@
+from golang:1.14
+workdir /awat/
+copy . /awat/
+run make build
+entrypoint ["/usr/bin/make", "e2e"]


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Adds a Dockerfile for building an image through which to run the E2E tests in k8s.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Part of [MM-38160](https://mattermost.atlassian.net/browse/MM-38160)
