### PR TITLE
Standardize resource creation store logic

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -112,7 +112,7 @@ func TestTranslations(t *testing.T) {
 
 	t.Run("start a new translation", func(t *testing.T) {
 		store.EXPECT().
-			StoreTranslation(
+			CreateTranslation(
 				// a more specific expectation could be applied here, but it
 				// doesn't seem worth the time to define a Matcher and get it
 				// all working just to ignore the nondeterministic ID that's

--- a/internal/api/store.go
+++ b/internal/api/store.go
@@ -10,7 +10,7 @@ type Store interface {
 	GetTranslation(id string) (*model.Translation, error)
 	GetTranslationsByInstallation(id string) ([]*model.Translation, error)
 	GetAllTranslations() ([]*model.Translation, error)
-	StoreTranslation(t *model.Translation) error
+	CreateTranslation(t *model.Translation) error
 	UpdateTranslation(t *model.Translation) error
 
 	GetAndClaimNextReadyImport(provisionerID string) (*model.Import, error)

--- a/internal/api/translation.go
+++ b/internal/api/translation.go
@@ -53,7 +53,7 @@ func handleStartTranslation(c *Context, w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	err = c.Store.StoreTranslation(translation)
+	err = c.Store.CreateTranslation(translation)
 	if err != nil {
 		c.Logger.WithError(err).Errorf("failed to store the translation request in the database")
 		w.WriteHeader(http.StatusInternalServerError)

--- a/internal/mocks/api/store.go
+++ b/internal/mocks/api/store.go
@@ -78,18 +78,18 @@ func (mr *MockStoreMockRecorder) GetAllTranslations() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllTranslations", reflect.TypeOf((*MockStore)(nil).GetAllTranslations))
 }
 
-// StoreTranslation mocks base method
-func (m *MockStore) StoreTranslation(t *model.Translation) error {
+// CreateTranslation mocks base method
+func (m *MockStore) CreateTranslation(t *model.Translation) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StoreTranslation", t)
+	ret := m.ctrl.Call(m, "CreateTranslation", t)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// StoreTranslation indicates an expected call of StoreTranslation
-func (mr *MockStoreMockRecorder) StoreTranslation(t interface{}) *gomock.Call {
+// CreateTranslation indicates an expected call of CreateTranslation
+func (mr *MockStoreMockRecorder) CreateTranslation(t interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreTranslation", reflect.TypeOf((*MockStore)(nil).StoreTranslation), t)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTranslation", reflect.TypeOf((*MockStore)(nil).CreateTranslation), t)
 }
 
 // UpdateTranslation mocks base method

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -96,6 +96,7 @@ var migrations = []migration{
 			}
 			defer uploadRows.Close()
 
+			var uploadUpdates []string
 			for uploadRows.Next() {
 				var id string
 				var createAt, completeAt int64
@@ -103,14 +104,17 @@ var migrations = []migration{
 				if err != nil {
 					return err
 				}
-				_, err = e.Exec(fmt.Sprintf(`UPDATE upload SET CreateAt = %d, CompleteAt = %d WHERE ID = '%s';`, m(createAt), m(completeAt), id))
-				if err != nil {
-					return err
-				}
+				uploadUpdates = append(uploadUpdates, fmt.Sprintf(`UPDATE upload SET CreateAt = %d, CompleteAt = %d WHERE ID = '%s';`, m(createAt), m(completeAt), id))
 			}
 			err = uploadRows.Err()
 			if err != nil {
 				return err
+			}
+			for _, update := range uploadUpdates {
+				_, err = e.Exec(update)
+				if err != nil {
+					return err
+				}
 			}
 
 			translationRows, err := e.Query(`SELECT ID, CreateAt, StartAt, CompleteAt FROM translation;`)
@@ -119,6 +123,7 @@ var migrations = []migration{
 			}
 			defer translationRows.Close()
 
+			var translationUpdates []string
 			for translationRows.Next() {
 				var id string
 				var createAt, startAt, completeAt int64
@@ -126,16 +131,20 @@ var migrations = []migration{
 				if err != nil {
 					return err
 				}
-				_, err = e.Exec(fmt.Sprintf(`UPDATE translation SET CreateAt = %d, StartAt = %d, CompleteAt = %d WHERE ID = '%s';`, m(createAt), m(startAt), m(completeAt), id))
-				if err != nil {
-					return err
-				}
+				translationUpdates = append(translationUpdates, fmt.Sprintf(`UPDATE translation SET CreateAt = %d, StartAt = %d, CompleteAt = %d WHERE ID = '%s';`, m(createAt), m(startAt), m(completeAt), id))
 			}
 			err = translationRows.Err()
 			if err != nil {
 				return err
 			}
+			for _, update := range translationUpdates {
+				_, err = e.Exec(update)
+				if err != nil {
+					return err
+				}
+			}
 
+			var importUpdates []string
 			importRows, err := e.Query(`SELECT ID, CreateAt, StartAt, CompleteAt FROM import;`)
 			if err != nil {
 				return err
@@ -149,14 +158,17 @@ var migrations = []migration{
 				if err != nil {
 					return err
 				}
-				_, err = e.Exec(fmt.Sprintf(`UPDATE import SET CreateAt = %d, StartAt = %d, CompleteAt = %d WHERE ID = '%s';`, m(createAt), m(startAt), m(completeAt), id))
-				if err != nil {
-					return err
-				}
+				importUpdates = append(importUpdates, fmt.Sprintf(`UPDATE import SET CreateAt = %d, StartAt = %d, CompleteAt = %d WHERE ID = '%s';`, m(createAt), m(startAt), m(completeAt), id))
 			}
 			err = importRows.Err()
 			if err != nil {
 				return err
+			}
+			for _, update := range importUpdates {
+				_, err = e.Exec(update)
+				if err != nil {
+					return err
+				}
 			}
 
 			return nil

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -5,6 +5,8 @@
 package store
 
 import (
+	"fmt"
+
 	"github.com/blang/semver"
 )
 
@@ -77,6 +79,87 @@ var migrations = []migration{
 				);
 		`)
 			return err
+		},
+	},
+	{semver.MustParse("0.2.0"), semver.MustParse("0.3.0"),
+		func(e execer) error {
+			m := func(i int64) int64 {
+				if i == 0 {
+					return 0
+				}
+				return i / 1000
+			}
+
+			uploadRows, err := e.Query(`SELECT ID, CreateAt, CompleteAt FROM upload;`)
+			if err != nil {
+				return err
+			}
+			defer uploadRows.Close()
+
+			for uploadRows.Next() {
+				var id string
+				var createAt, completeAt int64
+				err := uploadRows.Scan(&id, &createAt, &completeAt)
+				if err != nil {
+					return err
+				}
+				_, err = e.Exec(fmt.Sprintf(`UPDATE upload SET CreateAt = %d, CompleteAt = %d WHERE ID = '%s';`, m(createAt), m(completeAt), id))
+				if err != nil {
+					return err
+				}
+			}
+			err = uploadRows.Err()
+			if err != nil {
+				return err
+			}
+
+			translationRows, err := e.Query(`SELECT ID, CreateAt, StartAt, CompleteAt FROM translation;`)
+			if err != nil {
+				return err
+			}
+			defer translationRows.Close()
+
+			for translationRows.Next() {
+				var id string
+				var createAt, startAt, completeAt int64
+				err := translationRows.Scan(&id, &createAt, &startAt, &completeAt)
+				if err != nil {
+					return err
+				}
+				_, err = e.Exec(fmt.Sprintf(`UPDATE translation SET CreateAt = %d, StartAt = %d, CompleteAt = %d WHERE ID = '%s';`, m(createAt), m(startAt), m(completeAt), id))
+				if err != nil {
+					return err
+				}
+			}
+			err = translationRows.Err()
+			if err != nil {
+				return err
+			}
+
+			importRows, err := e.Query(`SELECT ID, CreateAt, StartAt, CompleteAt FROM import;`)
+			if err != nil {
+				return err
+			}
+			defer importRows.Close()
+
+			for importRows.Next() {
+				var id string
+				var createAt, startAt, completeAt int64
+				err := importRows.Scan(&id, &createAt, &startAt, &completeAt)
+				if err != nil {
+					return err
+				}
+				_, err = e.Exec(fmt.Sprintf(`UPDATE import SET CreateAt = %d, StartAt = %d, CompleteAt = %d WHERE ID = '%s';`, m(createAt), m(startAt), m(completeAt), id))
+				if err != nil {
+					return err
+				}
+			}
+			err = importRows.Err()
+			if err != nil {
+				return err
+			}
+
+			return nil
 		},
 	},
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -109,6 +109,7 @@ func (sqlStore *SQLStore) selectBuilder(q sqlx.Queryer, dest interface{}, b buil
 // It allows the use of *sqlx.Db and *sqlx.Tx.
 type execer interface {
 	Exec(query string, args ...interface{}) (sql.Result, error)
+	Query(query string, args ...interface{}) (*sql.Rows, error)
 	DriverName() string
 }
 

--- a/internal/store/translation.go
+++ b/internal/store/translation.go
@@ -110,17 +110,18 @@ func (sqlStore *SQLStore) GetTranslationReadyToStart() (*model.Translation, erro
 	return translations[0], nil
 }
 
-// StoreTranslation saves the specified Translation to the database,
-// assuming it is new
-func (sqlStore *SQLStore) StoreTranslation(translation *model.Translation) error {
+// CreateTranslation stores a new translation.
+func (sqlStore *SQLStore) CreateTranslation(translation *model.Translation) error {
+	translation.ID = model.NewID()
+	translation.CreateAt = model.GetMillis()
+
 	_, err := sqlStore.execBuilder(sqlStore.db, sq.
 		Insert(TranslationTableName).
 		SetMap(map[string]interface{}{
-			"CompleteAt": translation.CompleteAt,
-			"CreateAt":   model.Timestamp(),
-			"StartAt":    translation.StartAt,
-
 			"ID":             translation.ID,
+			"CreateAt":       translation.CreateAt,
+			"StartAt":        translation.StartAt,
+			"CompleteAt":     translation.CompleteAt,
 			"InstallationID": translation.InstallationID,
 			"LockedBy":       translation.LockedBy,
 			"Resource":       translation.Resource,
@@ -132,16 +133,14 @@ func (sqlStore *SQLStore) StoreTranslation(translation *model.Translation) error
 	return err
 }
 
-// UpdateTranslation stores changes to the input translation in the
-// database
+// UpdateTranslation stores changes to the provided translation in the database.
 func (sqlStore *SQLStore) UpdateTranslation(translation *model.Translation) error {
 	_, err := sqlStore.execBuilder(sqlStore.db, sq.
 		Update(TranslationTableName).
 		SetMap(map[string]interface{}{
-			"CompleteAt": translation.CompleteAt,
-			"CreateAt":   translation.CreateAt,
-			"StartAt":    translation.StartAt,
-
+			"CompleteAt":     translation.CompleteAt,
+			"CreateAt":       translation.CreateAt,
+			"StartAt":        translation.StartAt,
 			"ID":             translation.ID,
 			"InstallationID": translation.InstallationID,
 			"LockedBy":       translation.LockedBy,

--- a/internal/store/upload.go
+++ b/internal/store/upload.go
@@ -45,13 +45,13 @@ func (sqlStore *SQLStore) GetUpload(id string) (*model.Upload, error) {
 	return upload, nil
 }
 
-// CreateUpload creates a upload object in the database to represent a
+// CreateUpload creates an upload object in the database to represent a
 // started upload
 func (sqlStore *SQLStore) CreateUpload(id string) error {
 	_, err := sqlStore.execBuilder(sqlStore.db, sq.
 		Insert(UploadTableName).
 		SetMap(map[string]interface{}{
-			"CreateAt":   model.Timestamp(),
+			"CreateAt":   model.GetMillis(),
 			"CompleteAt": 0,
 			"ID":         id,
 			"Error":      "",
@@ -68,7 +68,7 @@ func (sqlStore *SQLStore) CompleteUpload(uploadID, errorMessage string) error {
 		Update(UploadTableName).
 		Where("ID = ?", uploadID).
 		SetMap(map[string]interface{}{
-			"CompleteAt": model.Timestamp(),
+			"CompleteAt": model.GetMillis(),
 			"ID":         uploadID,
 			"Error":      errorMessage,
 		}),

--- a/internal/supervisor/import.go
+++ b/internal/supervisor/import.go
@@ -86,7 +86,7 @@ func (s *ImportSupervisor) supervise() {
 			continue
 		}
 
-		i.CompleteAt = model.Timestamp()
+		i.CompleteAt = model.GetMillis()
 		err = s.store.UpdateImport(i)
 		if err != nil {
 			logger.WithError(err).Error("Failed to mark import as completed")

--- a/internal/supervisor/translation.go
+++ b/internal/supervisor/translation.go
@@ -81,7 +81,7 @@ func (s *TranslationSupervisor) supervise() {
 		return
 	}
 
-	translation.StartAt = model.Timestamp()
+	translation.StartAt = model.GetMillis()
 	err = s.store.UpdateTranslation(translation)
 	if err != nil {
 		logger.WithError(err).Error("Failed to mark translation as started")
@@ -94,7 +94,7 @@ func (s *TranslationSupervisor) supervise() {
 		return
 	}
 
-	translation.CompleteAt = model.Timestamp()
+	translation.CompleteAt = model.GetMillis()
 	err = s.store.UpdateTranslation(translation)
 	if err != nil {
 		logger.WithError(err).Error("Failed to mark translation as completed")
@@ -103,7 +103,7 @@ func (s *TranslationSupervisor) supervise() {
 
 	importResource := fmt.Sprintf("%s/%s", s.bucket, output)
 	imp := model.NewImport(translation.ID, importResource)
-	err = s.store.StoreImport(imp)
+	err = s.store.CreateImport(imp)
 	if err != nil {
 		logger.WithError(err).Error("Failed to create an import for translation")
 		return

--- a/model/client_test.go
+++ b/model/client_test.go
@@ -105,7 +105,7 @@ func TestTranslationClient(t *testing.T) {
 
 	t.Run("start a new translation", func(t *testing.T) {
 		store.EXPECT().
-			StoreTranslation(
+			CreateTranslation(
 				// a more specific expectation could be applied here, but it
 				// doesn't seem worth the time to define a Matcher and get it
 				// all working just to ignore the nondeterministic ID that's

--- a/model/helpers.go
+++ b/model/helpers.go
@@ -5,15 +5,12 @@
 package model
 
 import (
-	"time"
-
 	cloudModel "github.com/mattermost/mattermost-cloud/model"
 )
 
-// Timestamp produces a millisecond-precision timestamp in a standard
-// way with the other Mattermost APIs
-func Timestamp() int64 {
-	return time.Now().UnixNano() / 1000
+// GetMillis is a convenience method to get milliseconds since epoch.
+func GetMillis() int64 {
+	return cloudModel.GetMillis()
 }
 
 // NewID produces IDs for unique objects

--- a/model/import.go
+++ b/model/import.go
@@ -22,12 +22,12 @@ const (
 // into an Installation in order to track that process
 type Import struct {
 	ID            string
-	CreateAt      int64
-	CompleteAt    int64
-	StartAt       int64
-	LockedBy      string
 	TranslationID string
 	Resource      string
+	CreateAt      int64
+	StartAt       int64
+	CompleteAt    int64
+	LockedBy      string
 	Error         string
 }
 
@@ -46,14 +46,11 @@ type ImportCompletedWorkRequest struct {
 	Error      string
 }
 
-// NewImport creates an Import with the appropriate creation-time
-// metadata and associates it with the given translationID
-func NewImport(translationID string, input string) *Import {
+// NewImport returns a new import resource.
+func NewImport(translationID, importResource string) *Import {
 	return &Import{
-		ID:            NewID(),
 		TranslationID: translationID,
-		CreateAt:      Timestamp(),
-		Resource:      input,
+		Resource:      importResource,
 	}
 }
 

--- a/model/translation.go
+++ b/model/translation.go
@@ -22,10 +22,10 @@ const (
 type Translation struct {
 	ID             string
 	InstallationID string
+	Resource       string
+	Type           BackupType
 	Team           string
 	Users          int
-	Type           BackupType
-	Resource       string
 	CreateAt       int64
 	StartAt        int64
 	CompleteAt     int64
@@ -47,8 +47,7 @@ func (t *Translation) State() string {
 	return TranslationStateComplete
 }
 
-// NewTranslationFromRequest creates a new Translation from a
-// TranslationRequest
+// NewTranslationFromRequest returns a new Translation from a TranslationRequest.
 func NewTranslationFromRequest(translationRequest *TranslationRequest) *Translation {
 	teamName := translationRequest.Team
 	if translationRequest.Type != MattermostWorkspaceBackupType {
@@ -56,7 +55,6 @@ func NewTranslationFromRequest(translationRequest *TranslationRequest) *Translat
 	}
 
 	return &Translation{
-		ID:             NewID(),
 		InstallationID: translationRequest.InstallationID,
 		Type:           translationRequest.Type,
 		Resource:       translationRequest.Archive,


### PR DESCRIPTION
This change does the following:
 - Ensures ID and CreateAt values are generated as part of the
   store logic. This standardizes the process and also resolves
   a bug where the CreateAt value was not entered on the pointer
   that was passed in.
 - Change the timestamp logic to match the cloud provisioner. The
   previous logic did not calculate timestamps in the same way as
   our standard GetMillis() implementation.

Note: Changing the time logic should be safe for two reasons: we
haven't officially started doing customer imports and only the
sorting logic may be affected.

Fixes https://mattermost.atlassian.net/browse/MM-41204 and https://mattermost.atlassian.net/browse/MM-41246
