### PR TITLE
Cleanup API client

### DIFF
--- a/cmd/awat/import.go
+++ b/cmd/awat/import.go
@@ -80,10 +80,8 @@ var getImportByIDCmd = &cobra.Command{
 
 		if status == nil {
 			fmt.Printf("No Import found with ID %s", imprt)
-		}
-
-		if status != nil {
-			_ = printJSON(status)
+		} else {
+			printJSON(status)
 		}
 
 		return nil
@@ -115,17 +113,9 @@ var listImportCmd = &cobra.Command{
 		server, _ := cmd.Flags().GetString(serverFlag)
 		awat := model.NewClient(server)
 
-		var err error
-		var statuses []*model.ImportStatus
-		statuses, err = awat.ListImports()
-
+		statuses, err := awat.GetAllImports()
 		if err != nil {
 			return err
-		}
-
-		if len(statuses) == 0 {
-			fmt.Println("No imports found")
-			return nil
 		}
 
 		return printJSON(statuses)

--- a/cmd/awat/import.go
+++ b/cmd/awat/import.go
@@ -80,11 +80,9 @@ var getImportByIDCmd = &cobra.Command{
 
 		if status == nil {
 			fmt.Printf("No Import found with ID %s", imprt)
-		} else {
-			printJSON(status)
+			return nil
 		}
-
-		return nil
+		return printJSON(status)
 	},
 }
 

--- a/cmd/awat/server.go
+++ b/cmd/awat/server.go
@@ -21,7 +21,8 @@ import (
 	"github.com/mattermost/awat/internal/api"
 	"github.com/mattermost/awat/internal/store"
 	"github.com/mattermost/awat/internal/supervisor"
-	"github.com/mattermost/mattermost-cloud/model"
+	"github.com/mattermost/awat/model"
+	cmodel "github.com/mattermost/mattermost-cloud/model"
 )
 
 const (
@@ -165,8 +166,8 @@ var serverCmd = &cobra.Command{
 	},
 }
 
-func buildCloudClientAndCheckConnectivity(provisionerURL string) (*model.Client, error) {
-	cloudClient := model.NewClient(provisionerURL)
+func buildCloudClientAndCheckConnectivity(provisionerURL string) (*cmodel.Client, error) {
+	cloudClient := cmodel.NewClient(provisionerURL)
 	_, err := cloudClient.GetInstallationsCount(false)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to check provisioner connectivity")

--- a/internal/api/translation.go
+++ b/internal/api/translation.go
@@ -67,7 +67,8 @@ func handleStartTranslation(c *Context, w http.ResponseWriter, r *http.Request) 
 	c.Logger.WithFields(logrus.Fields{
 		"installation": translation.InstallationID,
 		"resource":     translation.Resource,
-	}).Debugf("Started new translation with ID %s", translation.ID)
+		"translation":  translation.ID,
+	}).Debug("Started new translation")
 }
 
 // handleGetTranslationStatus responds to GET /translation/{id} with

--- a/model/client.go
+++ b/model/client.go
@@ -136,8 +136,6 @@ func (c *Client) GetAllTranslations() ([]*TranslationStatus, error) {
 	switch resp.StatusCode {
 	case http.StatusOK:
 		return NewTranslationStatusListFromReader(resp.Body)
-	case http.StatusNotFound:
-		return nil, nil
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
@@ -156,8 +154,6 @@ func (c *Client) GetAllImports() ([]*ImportStatus, error) {
 	switch resp.StatusCode {
 	case http.StatusOK:
 		return NewImportStatusListFromReader(resp.Body)
-	case http.StatusNotFound:
-		return nil, nil
 
 	default:
 		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
@@ -231,26 +227,6 @@ func (c *Client) GetImportStatus(importID string) (*ImportStatus, error) {
 	switch resp.StatusCode {
 	case http.StatusOK:
 		return NewImportStatusFromReader(resp.Body)
-	case http.StatusNotFound:
-		return nil, nil
-
-	default:
-		return nil, errors.Errorf("failed with status code %d", resp.StatusCode)
-	}
-}
-
-// ListImports returns all Imports on the AWAT
-// TODO pagination
-func (c *Client) ListImports() ([]*ImportStatus, error) {
-	resp, err := c.doGet(c.buildURL("/imports"))
-	if err != nil {
-		return nil, err
-	}
-	defer closeBody(resp)
-
-	switch resp.StatusCode {
-	case http.StatusOK:
-		return NewImportStatusListFromReader(resp.Body)
 	case http.StatusNotFound:
 		return nil, nil
 

--- a/model/version.go
+++ b/model/version.go
@@ -1,0 +1,4 @@
+package model
+
+// BuildHash holds the git commit hash when we build the server
+var BuildHash string


### PR DESCRIPTION
This change fixes a few client return codes that don't match with
the underlying API responses. Also, proper build hash variable
storage is added to the model.

```release-note
Cleanup API client
```
