### PR TITLE
Improve installation adjustment logic

### DIFF
--- a/internal/supervisor/import.go
+++ b/internal/supervisor/import.go
@@ -162,45 +162,42 @@ func (s *ImportSupervisor) transitionImport(imp *model.Import, installation *clo
 // transitionImportRequested handles the transition for an import in the 'requested' state.
 // It checks the installation's readiness and prepares it for the import process.
 func (s *ImportSupervisor) transitionImportRequested(imp *model.Import, installation *cloud.InstallationDTO, logger log.FieldLogger) string {
-
 	if installation.State != cloud.InstallationStateStable {
 		logger.Debug("Waiting for installation to be stable")
 		return imp.State
 	}
 
-	var adjustmentRequired bool
-	size := installation.Size
-	if size != model.Size1000String {
-		logger.Infof("Resizing installation to %s", model.Size1000String)
-		size = model.Size1000String
-		adjustmentRequired = true
-	}
-
-	s3TimeoutEnv := installation.PriorityEnv[model.S3EnvKey]
-	if s3TimeoutEnv.Value != fmt.Sprintf("%d", model.S3ExtendedTimeout) {
-		logger.Info("Extending S3 timeout to 48 hours")
-		s3TimeoutEnv.Value = fmt.Sprintf("%d", model.S3ExtendedTimeout)
-		adjustmentRequired = true
-	}
-
-	if !adjustmentRequired {
-		logger.Info("No adjustments required")
+	logger.Info("Running pre-import installation configuration check")
+	patch := getPreImportPatch(installation.Installation, logger)
+	if patch == nil {
+		logger.Info("No installation adjustments required")
 		return model.ImportStateInProgress
 	}
 
-	logger.Info("Adjustments required")
-	patchInstallation := &cloud.PatchInstallationRequest{
-		Size: &size,
-		PriorityEnv: cloud.EnvVarMap{
-			model.S3EnvKey: s3TimeoutEnv,
-		},
+	logger.Info("Adjusting installation configuration")
+
+	var err error
+	if installation.APISecurityLock {
+		err = s.cloud.UnlockAPIForInstallation(installation.ID)
+		if err != nil {
+			logger.WithError(err).Error("Failed to unlock installation")
+			return imp.State
+		}
+
+		defer func() {
+			err = s.cloud.LockAPIForInstallation(installation.ID)
+			if err != nil {
+				logger.WithError(err).Error("Failed to relock installation")
+			}
+		}()
 	}
 
-	_, err := s.cloud.UpdateInstallation(installation.ID, patchInstallation)
+	_, err = s.cloud.UpdateInstallation(installation.ID, patch)
 	if err != nil {
 		logger.WithError(err).Error("Failed to update installation")
 		return imp.State
 	}
+
 	return model.ImportStateInstallationPreAdjustment
 }
 
@@ -277,48 +274,43 @@ func (s *ImportSupervisor) transitionImportInProgress(imp *model.Import, install
 	return model.ImportStateComplete
 }
 
-// transitionImportComplete handles the transition for an import in the 'complete' state.
-// It performs final adjustments and cleanup after the import is done.
+// transitionImportComplete handles the transition for an import in the 'complete'
+// state. It performs final adjustments and cleanup after the import is done.
 func (s *ImportSupervisor) transitionImportComplete(imp *model.Import, installation *cloud.InstallationDTO, logger log.FieldLogger) string {
 	if installation.State != cloud.InstallationStateStable {
 		logger.Debug("Waiting for installation to be stable")
 		return imp.State
 	}
 
-	logger.Debug("Installation is Stable")
-
-	var adjustmentRequired bool
-	size := installation.Size
-	if size == model.Size1000String {
-		logger.Infof("Resizing installation to %s", model.SizeCloud10Users)
-		size = model.SizeCloud10Users
-		adjustmentRequired = true
-	}
-
-	s3TimeoutEnv := installation.PriorityEnv[model.S3EnvKey]
-	if s3TimeoutEnv.Value == fmt.Sprintf("%d", model.S3ExtendedTimeout) {
-		logger.Info("Setting S3 timeout back to the default value")
-		s3TimeoutEnv.Value = fmt.Sprintf("%d", model.S3DefaultTimeout)
-		adjustmentRequired = true
-	}
-
-	if !adjustmentRequired {
-		logger.Info("No adjustments required")
+	logger.Info("Running post-import installation configuration check")
+	patch := getPostImportPatch(installation.Installation, logger)
+	if patch == nil {
+		logger.Info("No installation adjustments required")
 		if imp.Error != "" {
 			return model.ImportStateFailed
 		}
 		return model.ImportStateSucceeded
 	}
 
-	logger.Info("Adjustments required")
-	patchInstallation := &cloud.PatchInstallationRequest{
-		Size: &size,
-		PriorityEnv: cloud.EnvVarMap{
-			model.S3EnvKey: s3TimeoutEnv,
-		},
+	logger.Info("Adjusting installation configuration")
+
+	var err error
+	if installation.APISecurityLock {
+		err = s.cloud.UnlockAPIForInstallation(installation.ID)
+		if err != nil {
+			logger.WithError(err).Error("Failed to unlock installation")
+			return imp.State
+		}
+
+		defer func() {
+			err = s.cloud.LockAPIForInstallation(installation.ID)
+			if err != nil {
+				logger.WithError(err).Error("Failed to relock installation")
+			}
+		}()
 	}
 
-	_, err := s.cloud.UpdateInstallation(installation.ID, patchInstallation)
+	_, err = s.cloud.UpdateInstallation(installation.ID, patch)
 	if err != nil {
 		logger.WithError(err).Error("Failed to update installation")
 		return imp.State
@@ -338,17 +330,16 @@ func (s *ImportSupervisor) transitionImportInstallationPostAdjustment(imp *model
 	logger.Debug("Installation is Stable")
 
 	if installation.Size == model.Size1000String {
-		logger.Debug("Installation is not in the correct size")
+		logger.Warn("Installation is not in the correct size")
 		return model.ImportStateComplete
 	}
 
-	s3TimeoutEnv := installation.PriorityEnv[model.S3EnvKey]
-	if s3TimeoutEnv.Value == fmt.Sprintf("%d", model.S3ExtendedTimeout) {
-		logger.Debug("S3 timeout is not extended")
+	if installation.PriorityEnv[model.S3EnvKey].Value == fmt.Sprintf("%d", model.S3ExtendedTimeout) {
+		logger.Warn("S3 timeout is still extended")
 		return model.ImportStateComplete
 	}
 
-	logger.Info("Installation is in the correct size and S3 timeout is extended")
+	logger.Info("Installation has been reverted to default configuration")
 
 	if imp.Error != "" {
 		return model.ImportStateFailed
@@ -371,4 +362,70 @@ func startedImportIsComplete(installation *cloud.InstallationDTO) bool {
 		return false
 	}
 	return true
+}
+
+func getPreImportPatch(installation *cloud.Installation, logger log.FieldLogger) *cloud.PatchInstallationRequest {
+	var adjustmentRequired bool
+	patch := &cloud.PatchInstallationRequest{}
+
+	importSize := model.Size1000String
+	if installation.Size != importSize {
+		logger.Debugf("Resizing installation to %s", importSize)
+		patch.Size = &importSize
+		adjustmentRequired = true
+	}
+
+	// For the S3 timeout we need to look at both the priority and normal env
+	// vars for the installation to see if either is set.
+	installationS3TimeoutEnvValue := installation.PriorityEnv[model.S3EnvKey].Value
+	if installationS3TimeoutEnvValue == "" {
+		installationS3TimeoutEnvValue = installation.MattermostEnv[model.S3EnvKey].Value
+	}
+
+	importS3TimeoutString := fmt.Sprintf("%d", model.S3ExtendedTimeout)
+	if installationS3TimeoutEnvValue != importS3TimeoutString {
+		logger.Debugf("Extending S3 timeout to 48 hours")
+		patch.PriorityEnv = cloud.EnvVarMap{
+			model.S3EnvKey: cloud.EnvVar{Value: importS3TimeoutString},
+		}
+		adjustmentRequired = true
+	}
+
+	if !adjustmentRequired {
+		return nil
+	}
+
+	return patch
+}
+
+func getPostImportPatch(installation *cloud.Installation, logger log.FieldLogger) *cloud.PatchInstallationRequest {
+	var adjustmentRequired bool
+	patch := &cloud.PatchInstallationRequest{}
+
+	defaultSize := model.SizeCloud10Users
+	if installation.Size == model.Size1000String {
+		logger.Debugf("Resizing installation to %s", defaultSize)
+		patch.Size = &defaultSize
+		adjustmentRequired = true
+	}
+
+	if installation.PriorityEnv[model.S3EnvKey].Value == fmt.Sprintf("%d", model.S3ExtendedTimeout) {
+		// NOTE: We want to clear the priority env var instead of setting it to
+		// a default value so that standard group environment variables are not
+		// ignored on the installation. Clearing the priority env vars will
+		// remove other custom env vars that were set. In order to not add extra
+		// complexity that would be needed to see if other custom env vars need
+		// to be re-applied as a follow-up step, we will assume that clearing
+		// everything is okay. Installations receiving imports should always be
+		// newly-created so it's unlikely they should have overrides.
+		logger.Debug("Clearing all priority env to remove S3 timeout increase")
+		patch.PriorityEnv = cloud.EnvVarMap{}
+		adjustmentRequired = true
+	}
+
+	if !adjustmentRequired {
+		return nil
+	}
+
+	return patch
 }

--- a/internal/supervisor/import_test.go
+++ b/internal/supervisor/import_test.go
@@ -1,0 +1,133 @@
+package supervisor
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/mattermost/awat/model"
+	cloud "github.com/mattermost/mattermost-cloud/model"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPreImportPatch(t *testing.T) {
+	importSize := model.Size1000String
+	timeoutString := fmt.Sprintf("%d", model.S3ExtendedTimeout)
+
+	var testCases = []struct {
+		testName     string
+		installation *cloud.Installation
+		patch        *cloud.PatchInstallationRequest
+	}{
+		{
+			"no updates",
+			&cloud.Installation{
+				Size: importSize,
+				PriorityEnv: cloud.EnvVarMap{
+					model.S3EnvKey: cloud.EnvVar{Value: timeoutString},
+				},
+			},
+			nil,
+		},
+		{
+			"all updates",
+			&cloud.Installation{Size: model.SizeCloud10Users},
+			&cloud.PatchInstallationRequest{
+				Size: &importSize,
+				PriorityEnv: cloud.EnvVarMap{
+					model.S3EnvKey: cloud.EnvVar{Value: timeoutString},
+				},
+			},
+		},
+		{
+			"only size",
+			&cloud.Installation{
+				Size: model.SizeCloud10Users,
+				PriorityEnv: cloud.EnvVarMap{
+					model.S3EnvKey: cloud.EnvVar{Value: timeoutString},
+				},
+			},
+			&cloud.PatchInstallationRequest{
+				Size: &importSize,
+			},
+		},
+		{
+			"only s3 timeout",
+			&cloud.Installation{
+				Size: importSize,
+			},
+			&cloud.PatchInstallationRequest{
+				PriorityEnv: cloud.EnvVarMap{
+					model.S3EnvKey: cloud.EnvVar{Value: timeoutString},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			logger := log.WithField("test", tc.testName)
+			require.Equal(t, tc.patch, getPreImportPatch(tc.installation, logger))
+		})
+	}
+}
+
+func TestGetPostImportPatch(t *testing.T) {
+	defaultSize := model.SizeCloud10Users
+	timeoutString := fmt.Sprintf("%d", model.S3ExtendedTimeout)
+
+	var testCases = []struct {
+		testName     string
+		installation *cloud.Installation
+		patch        *cloud.PatchInstallationRequest
+	}{
+		{
+			"no updates",
+			&cloud.Installation{
+				Size: defaultSize,
+			},
+			nil,
+		},
+		{
+			"all updates",
+			&cloud.Installation{
+				Size: model.Size1000String,
+				PriorityEnv: cloud.EnvVarMap{
+					model.S3EnvKey: cloud.EnvVar{Value: timeoutString},
+				},
+			},
+			&cloud.PatchInstallationRequest{
+				Size:        &defaultSize,
+				PriorityEnv: cloud.EnvVarMap{},
+			},
+		},
+		{
+			"only size",
+			&cloud.Installation{
+				Size: model.Size1000String,
+			},
+			&cloud.PatchInstallationRequest{
+				Size: &defaultSize,
+			},
+		},
+		{
+			"only s3 timeout",
+			&cloud.Installation{
+				Size: defaultSize,
+				PriorityEnv: cloud.EnvVarMap{
+					model.S3EnvKey: cloud.EnvVar{Value: timeoutString},
+				},
+			},
+			&cloud.PatchInstallationRequest{
+				PriorityEnv: cloud.EnvVarMap{},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			logger := log.WithField("test", tc.testName)
+			require.Equal(t, tc.patch, getPostImportPatch(tc.installation, logger))
+		})
+	}
+}


### PR DESCRIPTION
This change does the following:
 - Adds a check to see if installations have a security lock. If they do, the installation is unlocked, updated, and then relocked.
 - Refactor installation patching logic and add tests.
 - Fix an issue where the default S3 timeout value remains applied as a priority env var after import completes.
 - Fix incorrect logging information.

Fixes https://mattermost.atlassian.net/browse/CLD-8063 and https://mattermost.atlassian.net/browse/CLD-8061

```release-note
Improve installation adjustment logic
```
