### PR TITLE
Disable file extraction for bulk imports

### DIFF
--- a/internal/supervisor/import_test.go
+++ b/internal/supervisor/import_test.go
@@ -24,7 +24,8 @@ func TestGetPreImportPatch(t *testing.T) {
 			&cloud.Installation{
 				Size: importSize,
 				PriorityEnv: cloud.EnvVarMap{
-					model.S3EnvKey: cloud.EnvVar{Value: timeoutString},
+					model.S3EnvKey:          cloud.EnvVar{Value: timeoutString},
+					model.ExtractContentKey: cloud.EnvVar{Value: model.ExtractContentDisabled},
 				},
 			},
 			nil,
@@ -35,7 +36,8 @@ func TestGetPreImportPatch(t *testing.T) {
 			&cloud.PatchInstallationRequest{
 				Size: &importSize,
 				PriorityEnv: cloud.EnvVarMap{
-					model.S3EnvKey: cloud.EnvVar{Value: timeoutString},
+					model.S3EnvKey:          cloud.EnvVar{Value: timeoutString},
+					model.ExtractContentKey: cloud.EnvVar{Value: model.ExtractContentDisabled},
 				},
 			},
 		},
@@ -44,7 +46,8 @@ func TestGetPreImportPatch(t *testing.T) {
 			&cloud.Installation{
 				Size: model.SizeCloud10Users,
 				PriorityEnv: cloud.EnvVarMap{
-					model.S3EnvKey: cloud.EnvVar{Value: timeoutString},
+					model.S3EnvKey:          cloud.EnvVar{Value: timeoutString},
+					model.ExtractContentKey: cloud.EnvVar{Value: model.ExtractContentDisabled},
 				},
 			},
 			&cloud.PatchInstallationRequest{
@@ -55,10 +58,27 @@ func TestGetPreImportPatch(t *testing.T) {
 			"only s3 timeout",
 			&cloud.Installation{
 				Size: importSize,
+				PriorityEnv: cloud.EnvVarMap{
+					model.ExtractContentKey: cloud.EnvVar{Value: model.ExtractContentDisabled},
+				},
 			},
 			&cloud.PatchInstallationRequest{
 				PriorityEnv: cloud.EnvVarMap{
 					model.S3EnvKey: cloud.EnvVar{Value: timeoutString},
+				},
+			},
+		},
+		{
+			"only file extract disable",
+			&cloud.Installation{
+				Size: importSize,
+				PriorityEnv: cloud.EnvVarMap{
+					model.S3EnvKey: cloud.EnvVar{Value: timeoutString},
+				},
+			},
+			&cloud.PatchInstallationRequest{
+				PriorityEnv: cloud.EnvVarMap{
+					model.ExtractContentKey: cloud.EnvVar{Value: model.ExtractContentDisabled},
 				},
 			},
 		},
@@ -93,7 +113,8 @@ func TestGetPostImportPatch(t *testing.T) {
 			&cloud.Installation{
 				Size: model.Size1000String,
 				PriorityEnv: cloud.EnvVarMap{
-					model.S3EnvKey: cloud.EnvVar{Value: timeoutString},
+					model.S3EnvKey:          cloud.EnvVar{Value: timeoutString},
+					model.ExtractContentKey: cloud.EnvVar{Value: model.ExtractContentDisabled},
 				},
 			},
 			&cloud.PatchInstallationRequest{

--- a/model/import.go
+++ b/model/import.go
@@ -22,11 +22,12 @@ const (
 	ImportStateSucceeded                  = "import-succeeded"
 	ImportStateFailed                     = "import-failed"
 
-	SizeCloud10Users  = "cloud10users"
-	Size1000String    = "1000users"
-	S3ExtendedTimeout = 48 * 60 * 60 * 1000
-	S3DefaultTimeout  = 10 * 60 * 1000
-	S3EnvKey          = "MM_FILESETTINGS_AMAZONS3REQUESTTIMEOUTMILLISECONDS"
+	SizeCloud10Users       = "cloud10users"
+	Size1000String         = "1000users"
+	S3ExtendedTimeout      = 48 * 60 * 60 * 1000
+	S3EnvKey               = "MM_FILESETTINGS_AMAZONS3REQUESTTIMEOUTMILLISECONDS"
+	ExtractContentDisabled = "false"
+	ExtractContentKey      = "MM_FILESETTINGS_EXTRACTCONTENT"
 )
 
 // AllImportStatesPendingWork contains all import states that indicate pending work.


### PR DESCRIPTION
File extraction is enabled by default in newer versions of Mattermost which greatly increases import time. This change ensures that extraction is disabled while imports are in progress to avoid this issue.

Fixes https://mattermost.atlassian.net/browse/CLD-9268

```release-note
Disable file extraction for bulk imports
```
